### PR TITLE
ci(dependabot): update dependabot.yml to include dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,15 @@ updates:
     directory: "/src/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      microsoft-maui:
+        patterns:
+          - "Microsoft.Maui.*"
+      community-maui:
+        patterns:
+          - "CommunityToolkit.Maui.*"
+
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,10 @@ updates:
     groups:
       microsoft-maui:
         patterns:
-          - "Microsoft.Maui.*"
+          - "Microsoft.Maui*"
       community-maui:
         patterns:
-          - "CommunityToolkit.Maui.*"
+          - "CommunityToolkit.Maui*"
 
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests


### PR DESCRIPTION
Added groups for Microsoft.Maui and CommunityToolkit.Maui dependencies.

### Description of Change
<!-- Enter description of the fix in this section -->

### Issues Fixed
<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #
<!-- Are you targeting main? All PRs should target the main branch unless otherwise noted. -->
